### PR TITLE
Allow a bigger input of bench command

### DIFF
--- a/bench_manager/bench_manager/doctype/bench_settings/bench_settings.js
+++ b/bench_manager/bench_manager/doctype/bench_settings/bench_settings.js
@@ -130,7 +130,7 @@ frappe.ui.form.on('Bench Settings', {
 			var dialog = new frappe.ui.Dialog({
 				title: 'Bench Command',
 				fields: [
-					{fieldname: 'bench_params', fieldtype: 'Data', reqd:true
+					{fieldname: 'bench_params', fieldtype: 'Small Text', reqd:true
 						, label: 'Command and parameters to bench. See bench --help. (Try putting --help in the input below)'}
 				]
 			});


### PR DESCRIPTION
User has a bigger input space to add bench command especially the one that take more characters in order they can be executed.